### PR TITLE
Add sizing token "sizing.button.xs"

### DIFF
--- a/creatives/ck/design-tokens.json
+++ b/creatives/ck/design-tokens.json
@@ -519,6 +519,10 @@
         "sm": {
           "value": "44",
           "type": "sizing"
+        },
+        "xs": {
+          "value": "32",
+          "type": "sizing"
         }
       },
       "form": {


### PR DESCRIPTION
Made sense to create this token considering the latest button controls needed on the PLP/PDP product cards.

Figma component location:
https://www.figma.com/file/G9LDeAEewyTiLjjfMq27Cq/Components?node-id=2691%3A22496